### PR TITLE
Fixes handling BytesIO correctly

### DIFF
--- a/nude.py
+++ b/nude.py
@@ -19,11 +19,11 @@ def is_nude(path_or_io):
 
 class Nude(object):
 
-    def __init__(self, path_or_io):
-        if isinstance(path_or_io, IOBase):
-            self.image = path_or_io
+    def __init__(self, path_or_io_or_image):
+        if isinstance(path_or_io_or_image, (str, IOBase)):
+            self.image = Image.open(path_or_io_or_image)
         else:
-            self.image = Image.open(path_or_io)
+            self.image = path_or_io_or_image
         bands = self.image.getbands()
         # convert greyscale to rgb
         if len(bands) == 1:


### PR DESCRIPTION
Passing a BytesIO object would be considered an instance of IOBase and therefore would _not_ open it as an image.

Now, it will use Image.open on both strings and IOBase objects, but will accept PIL.Image objects as well in the else clause.